### PR TITLE
add support for deployments API endpoints

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/github/data/Deployments.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/data/Deployments.scala
@@ -1,0 +1,216 @@
+package io.chrisdavenport.github.data
+
+import cats.implicits._
+import org.http4s.Uri
+import org.http4s.circe._
+import java.time.Instant
+import io.circe._
+import io.circe.syntax._
+
+object Deployments {
+
+  final case class DeploymentCreator(
+    id: Int,
+    login: String,
+    `type`: String,
+    siteAdmin: Boolean,
+    gravatarId: Option[String],
+    uri: Uri,
+    htmlUri: Uri,
+    organizationsUri: Uri,
+    receivedEventsUri: Uri,
+    reposUri: Uri,
+    subscriptionsUri: Uri,
+    avatarUri: Uri
+  )
+  object DeploymentCreator {
+
+    implicit val deploymentCreatorDecoder = new Decoder[DeploymentCreator] {
+      def apply(c: HCursor): Decoder.Result[DeploymentCreator] =
+        (
+          c.downField("id").as[Int],
+          c.downField("login").as[String],
+          c.downField("type").as[String],
+          c.downField("site_admin").as[Boolean],
+          c.downField("gravatar_id").as[Option[String]],
+          c.downField("url").as[Uri],
+          c.downField("html_url").as[Uri],
+          c.downField("organizations_url").as[Uri],
+          c.downField("received_events_url").as[Uri],
+          c.downField("repos_url").as[Uri],
+          c.downField("subscriptions_url").as[Uri],
+          c.downField("avatar_url").as[Uri]
+        ).mapN(DeploymentCreator.apply)
+    }
+  }
+  
+  final case class Deployment(
+    id: Int,
+    sha: Option[String],
+    ref: Option[String],
+    task: Option[String],
+    payload: Option[Json],
+    originalEnvironment: Option[String],
+    environment: Option[String],
+    description: Option[String],
+    creator: Option[DeploymentCreator],
+    createdAt: Option[Instant],
+    updatedAt: Option[Instant],
+    url: Uri,
+    statusesUri: Uri,
+    repositoryUri: Uri,
+    transientEnvironment: Option[Boolean], // an ADT would be good here but API is in preview
+    productionEnvironment: Option[Boolean] // an ADT would be good here but API is in preview
+  )
+  object Deployment {
+    implicit val deploymentDecoder = new Decoder[Deployment] {
+      def apply(c: HCursor): Decoder.Result[Deployment] =
+        (
+          c.downField("id").as[Int],
+          c.downField("sha").as[Option[String]],
+          c.downField("ref").as[Option[String]],
+          c.downField("task").as[Option[String]],
+          c.downField("payload").as[Option[Json]],
+          c.downField("original_environment").as[Option[String]],
+          c.downField("environment").as[Option[String]],
+          c.downField("description").as[Option[String]],
+          c.downField("creator").as[Option[DeploymentCreator]],
+          c.downField("created_at").as[Option[Instant]],
+          c.downField("updated_at").as[Option[Instant]],
+          c.downField("url").as[Uri],
+          c.downField("statuses_url").as[Uri],
+          c.downField("repository_url").as[Uri],
+          c.downField("transient_environment").as[Option[Boolean]],
+          c.downField("production_environment").as[Option[Boolean]]
+        ).mapN(Deployment.apply)
+    }
+  }
+
+  sealed trait DeploymentState
+  object DeploymentState {
+    final case object Error extends DeploymentState
+    final case object Failure extends DeploymentState
+    final case object Inactive extends DeploymentState
+    final case object InProgress extends DeploymentState
+    final case object Queued extends DeploymentState
+    final case object Pending extends DeploymentState
+    final case object Success extends DeploymentState
+    
+    implicit val deploymentCreatorDecoder = new Decoder[DeploymentState] {
+      def apply(c: HCursor): Decoder.Result[DeploymentState] =
+        c.as[String].flatMap {
+          case "error" => Error.asRight
+          case "failure" => Failure.asRight
+          case "inactive" => Inactive.asRight
+          case "in_progress" => InProgress.asRight
+          case "queued" => Queued.asRight
+          case "pending" => Pending.asRight
+          case "success" => Success.asRight
+          case s => Left(DecodingFailure(s"Invalid deployment state $s", c.history))
+        }
+    }
+
+    implicit val deploymentStateEncoder = new Encoder[DeploymentState] {
+      def apply(a: DeploymentState): Json = a match {
+        case Error => "error".asJson
+        case Failure => "failure".asJson
+        case Inactive => "inactive".asJson
+        case InProgress => "in_progress".asJson
+        case Queued => "queued".asJson
+        case Pending => "pending".asJson
+        case Success => "success".asJson
+      }
+    }
+  }
+  
+  final case class DeploymentStatus(
+    id: Int,
+    url: Uri,
+    state: DeploymentState,
+    creator: DeploymentCreator,
+    description: Option[String],
+    environment: Option[String],
+    createdAt: Instant,
+    updatedAt: Instant,
+    deploymentUri: Uri,
+    repositoryUri: Uri,
+    targetUri: Option[Uri],
+    environmentUri: Option[Uri],
+    logUri: Option[Uri]
+  )
+  object DeploymentStatus {
+
+    implicit val deploymentStatusDecoder = new Decoder[DeploymentStatus] {
+      def apply(c: HCursor): Decoder.Result[DeploymentStatus] =
+        (
+          c.downField("id").as[Int],
+          c.downField("url").as[Uri],
+          c.downField("state").as[DeploymentState],
+          c.downField("creator").as[DeploymentCreator],
+          c.downField("description").as[Option[String]],
+          c.downField("environment").as[Option[String]],
+          c.downField("created_at").as[Instant],
+          c.downField("updated_at").as[Instant],
+          c.downField("deployment_url").as[Uri],
+          c.downField("repository_url").as[Uri],
+          c.downField("target_url").as[Option[Uri]],
+          c.downField("environment_url").as[Option[Uri]],
+          c.downField("log_url").as[Option[Uri]]
+        ).mapN(DeploymentStatus.apply)
+    }
+  }
+
+  final case class NewDeployment(
+    ref: String,
+    environment: Option[String],
+    description: Option[String],
+    task: Option[String],
+    autoMerge: Option[Boolean],
+    requiredContexts: Option[List[String]],
+    payload: Option[Json],
+    transientEnvironment: Option[Boolean],
+    productionEnvironment: Option[Boolean]
+  )
+  object NewDeployment {
+    def create(ref: String) = NewDeployment(ref, None, None, None, None, None, None, None, None)
+
+    implicit val newDeploymentEncoder = new Encoder[NewDeployment] {
+      def apply(a: NewDeployment): Json = Json.obj(
+        "ref" -> a.ref.asJson,
+        "description" -> a.description.asJson,
+        "environment" -> a.environment.asJson,
+        "task" -> a.task.asJson,
+        "auto_merge" -> a.autoMerge.asJson,
+        "required_contexts" -> a.requiredContexts.asJson,
+        "payload" -> a.payload.asJson,
+        "transient_environment" -> a.transientEnvironment.asJson,
+        "production_environment" -> a.productionEnvironment.asJson
+      ).dropNullValues
+    }
+  }
+
+  final case class NewDeploymentStatus(
+    state: DeploymentState,
+    environment: Option[String],
+    environmentUri: Option[Uri],
+    targetUri: Option[Uri],
+    logUri: Option[Uri],
+    description: Option[String],
+    autoInactive: Option[Boolean]
+  )
+  object NewDeploymentStatus {
+    def create(state: DeploymentState) = NewDeploymentStatus(state, None, None, None, None, None, None)
+
+    implicit val newDeploymentStatusEncoder = new Encoder[NewDeploymentStatus] {
+      def apply(a: NewDeploymentStatus): Json = Json.obj(
+        "state" -> a.state.asJson,
+        "environment" -> a.environment.asJson,
+        "environment_url" -> a.environmentUri.asJson,
+        "target_url" -> a.targetUri.asJson,
+        "log_url" -> a.logUri.asJson,
+        "description" -> a.description.asJson,
+        "auto_inactive" -> a.autoInactive.asJson
+      ).dropNullValues
+    }
+  }
+}

--- a/core/src/main/scala/io/chrisdavenport/github/endpoints/Deployments.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/endpoints/Deployments.scala
@@ -1,0 +1,91 @@
+package io.chrisdavenport.github.endpoints
+
+import cats.implicits._
+import cats.data._
+import cats.effect._
+import io.chrisdavenport.github.data.Deployments._
+import org.http4s._
+import org.http4s.implicits._
+import org.http4s.client.Client
+
+import io.chrisdavenport.github.Auth
+import io.chrisdavenport.github.internals.GithubMedia._
+import io.chrisdavenport.github.internals.RequestConstructor
+
+object Deployments {
+
+  def deployment[F[_]: Sync](
+    owner: String,
+    repo: String,
+    deployment: Int,
+    auth: Auth
+  ): Kleisli[F, Client[F], Deployment] = 
+  RequestConstructor.runRequestWithNoBody[F, Deployment](
+      auth.some,
+      Method.GET,
+      uri"/repos" / owner / repo / "deployments" / deployment.toString()
+    )
+
+  def createDeployment[F[_]: Sync](
+    owner: String,
+    repo: String,
+    newDeployment: NewDeployment,
+    auth: Auth
+  ): Kleisli[F, Client[F], Deployment] =
+  RequestConstructor.runRequestWithBody[F, NewDeployment, Deployment](
+    auth.some,
+    Method.POST,
+    uri"/repos" / owner / repo / "deployments",
+    newDeployment
+  )
+
+  def listDeployments[F[_]: Sync](
+    owner: String,
+    repo: String,
+    auth: Auth
+  ): Kleisli[F, Client[F], List[Deployment]] = 
+  RequestConstructor.runRequestWithNoBody[F, List[Deployment]](
+      auth.some,
+      Method.GET,
+      uri"/repos" / owner / repo / "deployments"
+    )
+
+  def deploymentStatus[F[_]: Sync](
+    owner: String,
+    repo: String,
+    deployment: Int,
+    status: Int,
+    auth: Auth
+  ): Kleisli[F, Client[F], DeploymentStatus] = 
+  RequestConstructor.runRequestWithNoBody[F, DeploymentStatus](
+      auth.some,
+      Method.GET,
+      uri"/repos" / owner / repo / "deployments" / deployment.toString() / "statuses" / status.toString()
+    )
+
+  def createDeploymentStatuses[F[_]: Sync](
+    owner: String,
+    repo: String,
+    deployment: Int,
+    status: NewDeploymentStatus,
+    auth: Auth
+  ): Kleisli[F, Client[F], DeploymentStatus] = 
+  RequestConstructor.runRequestWithBody[F, NewDeploymentStatus, DeploymentStatus](
+      auth.some,
+      Method.POST,
+      uri"/repos" / owner / repo / "deployments" / deployment.toString() / "statuses",
+      status
+    )
+
+  def listDeploymentStatuses[F[_]: Sync](
+    owner: String,
+    repo: String,
+    deployment: Int,
+    auth: Auth
+  ): Kleisli[F, Client[F], List[DeploymentStatus]] = 
+  RequestConstructor.runRequestWithNoBody[F, List[DeploymentStatus]](
+      auth.some,
+      Method.GET,
+      uri"/repos" / owner / repo / "deployments" / deployment.toString() / "statuses"
+    )
+}

--- a/core/src/test/scala/io/chrisdavenport/github/endpoints/DeploymentsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/github/endpoints/DeploymentsSpec.scala
@@ -1,0 +1,353 @@
+package io.chrisdavenport.github.endpoints
+
+import org.specs2.mutable.Specification
+
+import cats.effect._
+import cats.effect.specs2.CatsEffect
+
+
+import io.circe.literal._
+import org.http4s._
+import org.http4s.implicits._
+import org.http4s.client._
+import org.http4s.circe._
+import org.http4s.dsl.io._
+
+import io.chrisdavenport.github.OAuth
+import io.chrisdavenport.github.data
+
+
+class DeploymentsSpec extends Specification with CatsEffect {
+
+  "Deployments" should {
+
+    "create a deployment" in {
+
+      val createDeploymentRoute = HttpRoutes.of[IO] {
+        case POST -> Root / "repos" / _ / _ / "deployments"  => Ok(json"""
+        {
+          "url": "https://api.github.com/repos/octocat/example/deployments/1",
+          "id": 1,
+          "node_id": "MDEwOkRlcGxveW1lbnQx",
+          "sha": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+          "ref": "topic-branch",
+          "task": "deploy",
+          "payload": {
+            "deploy": "migrate"
+          },
+          "original_environment": "staging",
+          "environment": "production",
+          "description": "Deploy request from hubot",
+          "creator": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "created_at": "2012-07-20T01:19:13Z",
+          "updated_at": "2012-07-20T01:19:13Z",
+          "statuses_url": "https://api.github.com/repos/octocat/example/deployments/1/statuses",
+          "repository_url": "https://api.github.com/repos/octocat/example",
+          "transient_environment": false,
+          "production_environment": true
+        }
+        """)
+      }
+      Deployments.createDeployment[IO](
+        "anything",
+        "anything",
+        data.Deployments.NewDeployment.create("topic-branch"),
+        OAuth("anything")
+      )
+      .run(Client.fromHttpApp(createDeploymentRoute.orNotFound))
+      .attempt
+      .map{_ must beRight}
+    }
+
+    "get a deployment" in {
+      val getDeploymentRoute = HttpRoutes.of[IO] {
+        case GET -> Root / "repos" / _ / _ / "deployments" / _  => Ok(json"""
+        {
+          "url": "https://api.github.com/repos/octocat/example/deployments/1",
+          "id": 1,
+          "node_id": "MDEwOkRlcGxveW1lbnQx",
+          "sha": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+          "ref": "topic-branch",
+          "task": "deploy",
+          "payload": {
+            "deploy": "migrate"
+          },
+          "original_environment": "staging",
+          "environment": "production",
+          "description": "Deploy request from hubot",
+          "creator": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "created_at": "2012-07-20T01:19:13Z",
+          "updated_at": "2012-07-20T01:19:13Z",
+          "statuses_url": "https://api.github.com/repos/octocat/example/deployments/1/statuses",
+          "repository_url": "https://api.github.com/repos/octocat/example",
+          "transient_environment": false,
+          "production_environment": true
+        }
+        """)
+      }
+      Deployments.deployment[IO](
+        "anything",
+        "anything",
+        1,
+        OAuth("anything")
+      )
+      .run(Client.fromHttpApp(getDeploymentRoute.orNotFound))
+      .attempt
+      .map{_ must beRight}
+    }
+
+    "list deployments" in {
+      val listDeploymentsRoute = HttpRoutes.of[IO] {
+        case GET -> Root / "repos" / _ / _ / "deployments" => Ok(json"""
+        [
+          {
+            "url": "https://api.github.com/repos/octocat/example/deployments/1",
+            "id": 1,
+            "node_id": "MDEwOkRlcGxveW1lbnQx",
+            "sha": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+            "ref": "topic-branch",
+            "task": "deploy",
+            "payload": {
+              "deploy": "migrate"
+            },
+            "original_environment": "staging",
+            "environment": "production",
+            "description": "Deploy request from hubot",
+            "creator": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "created_at": "2012-07-20T01:19:13Z",
+            "updated_at": "2012-07-20T01:19:13Z",
+            "statuses_url": "https://api.github.com/repos/octocat/example/deployments/1/statuses",
+            "repository_url": "https://api.github.com/repos/octocat/example",
+            "transient_environment": false,
+            "production_environment": true
+          }
+        ]
+        """)
+      }
+      Deployments.listDeployments[IO](
+        "anything",
+        "anything",
+        OAuth("anything")
+      )
+      .run(Client.fromHttpApp(listDeploymentsRoute.orNotFound))
+      .attempt
+      .map{_ must beRight}
+    }
+
+    "create a deployment status" in {
+
+      val createDeploymentStatusRoute = HttpRoutes.of[IO] {
+        case POST -> Root / "repos" / _ / _ / "deployments" / _ / "statuses"  => Ok(json"""
+        {
+          "url": "https://api.github.com/repos/octocat/example/deployments/42/statuses/1",
+          "id": 1,
+          "node_id": "MDE2OkRlcGxveW1lbnRTdGF0dXMx",
+          "state": "success",
+          "creator": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "description": "Deployment finished successfully.",
+          "environment": "production",
+          "target_url": "https://example.com/deployment/42/output",
+          "created_at": "2012-07-20T01:19:13Z",
+          "updated_at": "2012-07-20T01:19:13Z",
+          "deployment_url": "https://api.github.com/repos/octocat/example/deployments/42",
+          "repository_url": "https://api.github.com/repos/octocat/example",
+          "environment_url": "",
+          "log_url": "https://example.com/deployment/42/output"
+        }
+        """)
+      }
+      Deployments.createDeploymentStatuses[IO](
+        "anything",
+        "anything",
+        1,
+        data.Deployments.NewDeploymentStatus.create(data.Deployments.DeploymentState.Success),
+        OAuth("anything")
+      )
+      .run(Client.fromHttpApp(createDeploymentStatusRoute.orNotFound))
+      .attempt
+      .map{_ must beRight}
+    }
+
+    "get a deployment status" in {
+
+      val getDeploymentStatusRoute = HttpRoutes.of[IO] {
+        case GET -> Root / "repos" / _ / _ / "deployments" / _ / "statuses" / _  => Ok(json"""
+        {
+          "url": "https://api.github.com/repos/octocat/example/deployments/42/statuses/1",
+          "id": 1,
+          "node_id": "MDE2OkRlcGxveW1lbnRTdGF0dXMx",
+          "state": "success",
+          "creator": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "description": "Deployment finished successfully.",
+          "environment": "production",
+          "target_url": "https://example.com/deployment/42/output",
+          "created_at": "2012-07-20T01:19:13Z",
+          "updated_at": "2012-07-20T01:19:13Z",
+          "deployment_url": "https://api.github.com/repos/octocat/example/deployments/42",
+          "repository_url": "https://api.github.com/repos/octocat/example",
+          "environment_url": "",
+          "log_url": "https://example.com/deployment/42/output"
+        }
+        """)
+      }
+      Deployments.deploymentStatus[IO](
+        "anything",
+        "anything",
+        1,
+        1,
+        OAuth("anything")
+      )
+      .run(Client.fromHttpApp(getDeploymentStatusRoute.orNotFound))
+      .attempt
+      .map{_ must beRight}
+    }
+
+    "list deployment statuses" in {
+      val listDeploymentStatusesRoute = HttpRoutes.of[IO] {
+        case GET -> Root / "repos" / _ / _ / "deployments" / _ / "statuses" => Ok(json"""
+        [
+          {
+            "url": "https://api.github.com/repos/octocat/example/deployments/42/statuses/1",
+            "id": 1,
+            "node_id": "MDE2OkRlcGxveW1lbnRTdGF0dXMx",
+            "state": "success",
+            "creator": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "description": "Deployment finished successfully.",
+            "environment": "production",
+            "target_url": "https://example.com/deployment/42/output",
+            "created_at": "2012-07-20T01:19:13Z",
+            "updated_at": "2012-07-20T01:19:13Z",
+            "deployment_url": "https://api.github.com/repos/octocat/example/deployments/42",
+            "repository_url": "https://api.github.com/repos/octocat/example",
+            "environment_url": "",
+            "log_url": "https://example.com/deployment/42/output"
+          }
+        ]
+        """)
+      }
+      Deployments.listDeploymentStatuses[IO](
+        "anything",
+        "anything",
+        1,
+        OAuth("anything")
+      )
+      .run(Client.fromHttpApp(listDeploymentStatusesRoute.orNotFound))
+      .attempt
+      .map{_ must beRight}
+    }
+  }
+}


### PR DESCRIPTION
This is still WIP to some degree. We need to determine the best pathway to pass the custom media types for some endpoints. I'm open to following whatever direction you see fit.