### PR TITLE
Use relative urls in endpoints

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/github/endpoints/PullRequests.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/endpoints/PullRequests.scala
@@ -1,13 +1,11 @@
 package io.chrisdavenport.github.endpoints
 
 import cats.implicits._
-import cats.data._
 import cats.effect._
 import io.chrisdavenport.github.data.Issues
 import io.chrisdavenport.github.data.PullRequests._
 import org.http4s._
 import org.http4s.implicits._
-import org.http4s.client.Client
 
 import io.chrisdavenport.github.Auth
 import io.chrisdavenport.github.internals.GithubMedia._
@@ -21,7 +19,7 @@ object PullRequests {
     auth: Option[Auth]
   ) = RequestConstructor.runPaginatedRequest[F, List[SimplePullRequest]](
     auth,
-    uri"/repos" / owner / name / "pulls"
+    uri"repos" / owner / name / "pulls"
   )
 
   def pullRequest[F[_]: Sync](
@@ -32,7 +30,7 @@ object PullRequests {
   ) = RequestConstructor.runRequestWithNoBody[F, PullRequest](
     auth,
     Method.GET,
-    uri"/repos" / owner / name / "pulls" / issueNumber.toInt.toString
+    uri"repos" / owner / name / "pulls" / issueNumber.toInt.toString
   )
 
   def createPullRequest[F[_]: Sync](
@@ -43,7 +41,7 @@ object PullRequests {
   ) = RequestConstructor.runRequestWithBody[F, CreatePullRequest, PullRequest](
     auth.some,
     Method.POST,
-    uri"/repos" / owner / name / "pulls",
+    uri"repos" / owner / name / "pulls",
     createPullRequest
   )
 
@@ -56,7 +54,7 @@ object PullRequests {
   ) = RequestConstructor.runRequestWithBody[F, EditPullRequest, PullRequest](
     auth.some,
     Method.PATCH,
-    uri"/repos" / owner / name / "pulls" / issueNumber.toInt.toString ,
+    uri"repos" / owner / name / "pulls" / issueNumber.toInt.toString,
     updatePullRequest
   )
 

--- a/core/src/main/scala/io/chrisdavenport/github/endpoints/Repositories.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/endpoints/Repositories.scala
@@ -23,7 +23,7 @@ object Repositories {
   RequestConstructor.runRequestWithNoBody[F, Repo](
       auth,
       Method.GET,
-      uri"/repos" / owner / repo
+      uri"repos" / owner / repo
     )
 
   def createRepo[F[_]: Sync](
@@ -33,7 +33,7 @@ object Repositories {
   RequestConstructor.runRequestWithBody[F, NewRepo, Repo](
       auth.some,
       Method.POST,
-      uri"/user/repos",
+      uri"user/repos",
       newRepo
     )
 
@@ -45,7 +45,7 @@ object Repositories {
     RequestConstructor.runRequestWithBody[F, NewRepo, Repo](
       auth.some,
       Method.POST,
-      uri"/orgs" / org / "repos",
+      uri"orgs" / org / "repos",
       newRepo
     )
 
@@ -58,7 +58,7 @@ object Repositories {
   RequestConstructor.runRequestWithBody[F, EditRepo, Repo](
     auth.some,
     Method.PATCH,
-    uri"/repos" / owner / repo,
+    uri"repos" / owner / repo,
     editRepo
   )
 

--- a/core/src/main/scala/io/chrisdavenport/github/endpoints/Users.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/endpoints/Users.scala
@@ -19,21 +19,21 @@ object Users {
     RequestConstructor.runRequestWithNoBody[F, User](
       auth,
       Method.GET,
-      uri"/users" / username
+      uri"users" / username
     )
 
   def ownerInfoFor[F[_]: Sync](owner: String, auth: Option[Auth]): Kleisli[F, Client[F], Owner] =
     RequestConstructor.runRequestWithNoBody[F, Owner](
       auth,
       Method.GET,
-      uri"/users" / owner
+      uri"users" / owner
     )
 
   def userInfoAuthenticatedUser[F[_]: Sync](auth: Auth): Kleisli[F, Client[F], User] = 
     RequestConstructor.runRequestWithNoBody[F, User](
       auth.some,
       Method.GET,
-      uri"/user"
+      uri"user"
     )
 
   // We expose this as the returned list for each request
@@ -45,7 +45,7 @@ object Users {
   ): Kleisli[Stream[F, ?], Client[F], List[SimpleOwner]] = 
     RequestConstructor.runPaginatedRequest[F, List[SimpleOwner]](
       auth,
-      uri"/users".withOptionQueryParam("since", since)
+      uri"users".withOptionQueryParam("since", since)
     )
 
   // Patch so presently only updates. Unsure 
@@ -79,7 +79,7 @@ object Users {
     RequestConstructor.runRequestWithBody[F, Json, User](
       auth.some,
       Method.PATCH,
-      uri"/user",
+      uri"user",
       json
     )
   }

--- a/core/src/main/scala/io/chrisdavenport/github/endpoints/repositories/Content.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/endpoints/repositories/Content.scala
@@ -23,7 +23,7 @@ object Content {
     RequestConstructor.runRequestWithNoBody[F, Content](
       auth,
       Method.GET,
-      (uri"/repos" / owner / repo / "contents" / path)
+      (uri"repos" / owner / repo / "contents" / path)
         .withOptionQueryParam("ref", ref)
     )
 
@@ -35,7 +35,7 @@ object Content {
     RequestConstructor.runRequestWithNoBody[F, Content](
       auth,
       Method.GET,
-      uri"/repos" / owner / repo / "readme"
+      uri"repos" / owner / repo / "readme"
     )
 
   def createFile[F[_]: Sync](
@@ -46,7 +46,7 @@ object Content {
   ) = RequestConstructor.runRequestWithBody[F, CreateFile, ContentResult](
     auth.some,
     Method.PUT,
-    uri"/repos" / owner /  repo / "contents" / createFile.path,
+    uri"repos" / owner /  repo / "contents" / createFile.path,
     createFile
   )
 
@@ -58,7 +58,7 @@ object Content {
   ) = RequestConstructor.runRequestWithBody[F, UpdateFile, ContentResult](
     auth.some,
     Method.PUT,
-    uri"/repos" / owner /  repo / "contents" / updateFile.path,
+    uri"repos" / owner /  repo / "contents" / updateFile.path,
     updateFile
   )
 
@@ -70,7 +70,7 @@ object Content {
   ) = RequestConstructor.runRequestWithBody[F, DeleteFile, Unit](
     auth.some,
     Method.DELETE,
-    uri"/repos" / owner /  repo / "contents" / deleteFile.path,
+    uri"repos" / owner /  repo / "contents" / deleteFile.path,
     deleteFile
   )
   


### PR DESCRIPTION
Hi!

First: Thanks for the great project, it's very useful! :+1: 

I got a 404 error when connecting to an enterprise github instance. 

It turns out that absolute url's will strip the end of the api endpoint in `EnterpriseOAuth` due to how `Uri.resolve` works:

```scala
scala> :paste
// Entering paste mode (ctrl-D to finish)

import org.http4s._
import org.http4s.syntax._
val githubUri = uri"https://my-github.com/api/v3/"
val endpoint = uri"/user/repos"
val resolved = Uri.resolve(githubUri, endpoint)

// Exiting paste mode, now interpreting.

import org.http4s._
import org.http4s.syntax._
githubUri: org.http4s.Uri = https://my-github.com/api/v3/
endpoint: org.http4s.Uri = /user/repos
resolved: org.http4s.Uri = https://my-github.com/user/repos
```

When using relative urls in the code, it works as expected:

```scala
scala> :paste
// Entering paste mode (ctrl-D to finish)

import org.http4s._
import org.http4s.syntax._
val githubUri = uri"https://my-github.com/api/v3/"
val endpoint = uri"user/repos"
val resolved = Uri.resolve(githubUri, endpoint)

// Exiting paste mode, now interpreting.

import org.http4s._
import org.http4s.syntax._
githubUri: org.http4s.Uri = https://my-github.com/api/v3/
endpoint: org.http4s.Uri = user/repos
resolved: org.http4s.Uri = https://my-github.com/api/v3/user/repos
```