### PR TITLE
Replace Instant with ZonedDateTime

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/github/data/GitData.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/data/GitData.scala
@@ -5,7 +5,7 @@ import org.http4s._
 import org.http4s.circe._
 import io.circe._
 import io.circe.syntax._
-import java.time.Instant
+import java.time.ZonedDateTime
 
 object GitData {
   sealed trait Encoding extends Product with Serializable
@@ -29,7 +29,7 @@ object GitData {
   )
   object Blob {
     implicit val decoder = new Decoder[Blob]{
-      def apply(c: HCursor): Decoder.Result[Blob] = 
+      def apply(c: HCursor): Decoder.Result[Blob] =
         (
           c.downField("content").as[String],
           c.downField("url").as[Uri],
@@ -59,7 +59,7 @@ object GitData {
   )
   object NewBlob {
     implicit val decoder = new Decoder[NewBlob]{
-      def apply(c: HCursor): Decoder.Result[NewBlob] = 
+      def apply(c: HCursor): Decoder.Result[NewBlob] =
         (
           c.downField("url").as[Uri],
           c.downField("sha").as[String]
@@ -97,7 +97,7 @@ object GitData {
   sealed trait GitMode extends Product with Serializable
   object GitMode {
     case object Executable extends GitMode
-    case object File extends GitMode    
+    case object File extends GitMode
     case object Subdirectory extends GitMode
     case object Submodule extends GitMode
     case object Symlink extends GitMode
@@ -135,7 +135,7 @@ object GitData {
   )
   object GitTree {
     implicit val decoder = new Decoder[GitTree]{
-      def apply(c: HCursor): Decoder.Result[GitTree] = 
+      def apply(c: HCursor): Decoder.Result[GitTree] =
         (
           c.downField("path").as[String],
           c.downField("sha").as[String],
@@ -155,7 +155,7 @@ object GitData {
   )
   object Tree {
     implicit val decoder = new Decoder[Tree]{
-      def apply(c: HCursor): Decoder.Result[Tree] = 
+      def apply(c: HCursor): Decoder.Result[Tree] =
         (
           c.downField("sha").as[String],
           c.downField("url").as[Uri],
@@ -170,7 +170,7 @@ object GitData {
   sealed trait CreateGitTree extends Product with Serializable
   object CreateGitTree {
 
-    def fromGitTree(g: GitTree): CreateGitTree = 
+    def fromGitTree(g: GitTree): CreateGitTree =
       CreateGitTreeSha(
         g.path,
         g.sha.some,
@@ -184,7 +184,7 @@ object GitData {
       `type`: GitObjectType,
       mode: GitMode
     ) extends CreateGitTree
-    
+
     final case class CreateGitTreeBlob(
       path: String,
       content: String,
@@ -193,39 +193,39 @@ object GitData {
 
     implicit val encoder = new Encoder[CreateGitTree]{
       def apply(a: CreateGitTree): Json = a match {
-        case CreateGitTreeSha(path, sha, typ, mode) => 
+        case CreateGitTreeSha(path, sha, typ, mode) =>
           Json.obj(
             "path" -> path.asJson,
             "sha" -> sha.asJson,
             "type" -> typ.asJson,
             "mode" -> mode.asJson
           )
-        case CreateGitTreeBlob(path, content, mode) => 
+        case CreateGitTreeBlob(path, content, mode) =>
           Json.obj(
             "path" -> path.asJson,
             "type" -> (GitObjectType.Blob : GitObjectType).asJson,
             "mode" -> mode.merge.asJson,
             "content" -> content.asJson
           )
-        
+
       }
     }
   }
 
   /**
-   * The tree creation API accepts nested entries. 
+   * The tree creation API accepts nested entries.
    * If you specify both a tree and a nested path modifying that tree,
    * this endpoint will overwrite the contents of the tree with the new path contents,
    * and create a new tree structure.
-   * 
+   *
    * If you use this endpoint to add, delete, or modify the file contents in a tree,
    *  you will need to commit the tree and then update a branch to point to the commit.
    *  For more information see "Create a commit" and "Update a reference."
-   * 
+   *
    * POST /repos/:owner/:repo/git/trees
-   * 
+   *
    * @param tree Objects specifying the tree structure
-   * @param baseTreeSha The SHA1 of the tree you want to update with new data. 
+   * @param baseTreeSha The SHA1 of the tree you want to update with new data.
    *   If you don't set this, the commit will be created on top of everything;
    *   however, it will only contain your change, the rest of your files will show up as deleted.
    **/
@@ -235,7 +235,7 @@ object GitData {
   )
   object CreateTree {
     implicit val encoder = new Encoder[CreateTree]{
-      def apply(a: CreateTree): Json = 
+      def apply(a: CreateTree): Json =
         Json.obj(
           "tree" -> a.tree.asJson,
           "base_tree" -> a.baseTreeSha.asJson
@@ -247,15 +247,15 @@ object GitData {
   final case class GitUser(
     name: String,
     email: String,
-    date: Instant
+    date: ZonedDateTime
   )
   object GitUser {
     implicit val decoder = new Decoder[GitUser]{
-      def apply(c: HCursor): Decoder.Result[GitUser] = 
+      def apply(c: HCursor): Decoder.Result[GitUser] =
         (
           c.downField("name").as[String],
           c.downField("email").as[String],
-          c.downField("date").as[Instant]
+          c.downField("date").as[ZonedDateTime]
         ).mapN(GitUser.apply)
     }
     implicit val encoder = new Encoder[GitUser]{
@@ -274,7 +274,7 @@ object GitData {
 
   object CommitTree {
     implicit val decoder = new Decoder[CommitTree]{
-      def apply(c: HCursor): Decoder.Result[CommitTree] = 
+      def apply(c: HCursor): Decoder.Result[CommitTree] =
         (
           c.downField("sha").as[String],
           c.downField("url").as[Uri]
@@ -293,7 +293,7 @@ object GitData {
   )
   object GitCommit {
     implicit val decoder = new Decoder[GitCommit]{
-      def apply(c: HCursor): Decoder.Result[GitCommit] = 
+      def apply(c: HCursor): Decoder.Result[GitCommit] =
         (
           c.downField("message").as[String],
           c.downField("url").as[Uri],
@@ -331,13 +331,13 @@ object GitData {
   }
 
   final case class GitObject(
-    `type`: GitObjectType, 
+    `type`: GitObjectType,
     sha: String,
     uri: Uri
   )
   object GitObject {
     implicit val decoder = new Decoder[GitObject]{
-      def apply(c: HCursor): Decoder.Result[GitObject] = 
+      def apply(c: HCursor): Decoder.Result[GitObject] =
         (
           c.downField("type").as[GitObjectType],
           c.downField("sha").as[String],
@@ -398,7 +398,7 @@ object GitData {
   )
   object GitTag {
     implicit val decoder = new Decoder[GitTag]{
-      def apply(c: HCursor): Decoder.Result[GitTag] = 
+      def apply(c: HCursor): Decoder.Result[GitTag] =
         (
           c.downField("tag").as[String],
           c.downField("sha").as[String],

--- a/core/src/main/scala/io/chrisdavenport/github/data/PullRequests.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/data/PullRequests.scala
@@ -2,11 +2,14 @@ package io.chrisdavenport.github.data
 
 import cats._
 import cats.implicits._
-import java.time.Instant
-import org.http4s._
-import org.http4s.circe._
+
 import io.circe._
 import io.circe.syntax._
+
+import org.http4s._
+import org.http4s.circe._
+
+import java.time.ZonedDateTime
 
 object PullRequests {
 
@@ -18,7 +21,7 @@ object PullRequests {
   )
   object PullRequestLinks {
     implicit val decoder = new Decoder[PullRequestLinks]{
-      def apply(c: HCursor): Decoder.Result[PullRequestLinks] = 
+      def apply(c: HCursor): Decoder.Result[PullRequestLinks] =
         (
           c.downField("review_comments").downField("href").as[Uri],
           c.downField("comments").downField("href").as[Uri],
@@ -38,7 +41,7 @@ object PullRequests {
     case object Behind extends MergeableState
 
     implicit val decoder = new Decoder[MergeableState]{
-      def apply(c: HCursor): Decoder.Result[MergeableState] = 
+      def apply(c: HCursor): Decoder.Result[MergeableState] =
         c.as[String].flatMap{
           case "unknown" => Unknown.asRight
           case "clean" => Clean.asRight
@@ -68,10 +71,10 @@ object PullRequests {
     id: Int,
     body: Option[String],
     user: Users.SimpleUser,
-    createdAt: Instant,
-    updatedAt: Instant,
-    closedAt: Option[Instant],
-    mergedAt: Option[Instant],
+    createdAt: ZonedDateTime,
+    updatedAt: ZonedDateTime,
+    closedAt: Option[ZonedDateTime],
+    mergedAt: Option[ZonedDateTime],
     assignees: List[Users.SimpleUser],
     requestedReviewers: List[Users.SimpleUser],
     uri: Uri,
@@ -83,7 +86,7 @@ object PullRequests {
   )
   object SimplePullRequest {
     implicit val decoder = new Decoder[SimplePullRequest]{
-      def apply(c: HCursor): Decoder.Result[SimplePullRequest] = 
+      def apply(c: HCursor): Decoder.Result[SimplePullRequest] =
         (
           c.downField("state").as[Issues.IssueState],
           c.downField("number").as[Issues.IssueNumber],
@@ -91,10 +94,10 @@ object PullRequests {
           c.downField("id").as[Int],
           c.downField("body").as[Option[String]],
           c.downField("user").as[Users.SimpleUser],
-          c.downField("created_at").as[Instant],
-          c.downField("updated_at").as[Instant],
-          c.downField("closed_at").as[Option[Instant]],
-          c.downField("merged_at").as[Option[Instant]],
+          c.downField("created_at").as[ZonedDateTime],
+          c.downField("updated_at").as[ZonedDateTime],
+          c.downField("closed_at").as[Option[ZonedDateTime]],
+          c.downField("merged_at").as[Option[ZonedDateTime]],
           c.downField("assignees").as[List[Users.SimpleUser]],
           c.downField("requested_reviewers").as[Option[List[Users.SimpleUser]]]
             .map(_.getOrElse(MonoidK[List].empty)),
@@ -117,7 +120,7 @@ object PullRequests {
   )
   object PullRequestCommit {
     implicit val decoder = new Decoder[PullRequestCommit]{
-      def apply(c: HCursor): Decoder.Result[PullRequestCommit] = 
+      def apply(c: HCursor): Decoder.Result[PullRequestCommit] =
         (
           c.downField("label").as[String],
           c.downField("ref").as[String],
@@ -135,10 +138,10 @@ object PullRequests {
     id: Int,
     body: Option[String],
     user: Users.SimpleUser,
-    createdAt: Instant,
-    updatedAt: Instant,
-    closedAt: Option[Instant],
-    mergedAt: Option[Instant],
+    createdAt: ZonedDateTime,
+    updatedAt: ZonedDateTime,
+    closedAt: Option[ZonedDateTime],
+    mergedAt: Option[ZonedDateTime],
     assignees: List[Users.SimpleUser],
     requestedReviewers: List[Users.SimpleUser],
     uri: Uri,
@@ -170,10 +173,10 @@ object PullRequests {
         id: Int <- c.downField("id").as[Int]
         body: Option[String] <- c.downField("body").as[Option[String]]
         user: Users.SimpleUser <- c.downField("user").as[Users.SimpleUser]
-        createdAt: Instant <- c.downField("created_at").as[Instant]
-        updatedAt: Instant <- c.downField("updated_at").as[Instant]
-        closedAt: Option[Instant] <- c.downField("closed_at").as[Option[Instant]]
-        mergedAt: Option[Instant] <- c.downField("merged_at").as[Option[Instant]]
+        createdAt: ZonedDateTime <- c.downField("created_at").as[ZonedDateTime]
+        updatedAt: ZonedDateTime <- c.downField("updated_at").as[ZonedDateTime]
+        closedAt: Option[ZonedDateTime] <- c.downField("closed_at").as[Option[ZonedDateTime]]
+        mergedAt: Option[ZonedDateTime] <- c.downField("merged_at").as[Option[ZonedDateTime]]
         assignees: List[Users.SimpleUser] <- c.downField("assignees").as[List[Users.SimpleUser]]
         requestedReviewers: List[Users.SimpleUser] <- c.downField("requested_reviewers").as[Option[List[Users.SimpleUser]]]
           .map(_.getOrElse(MonoidK[List].empty))
@@ -230,7 +233,7 @@ object PullRequests {
     }
   }
 
-  
+
 
   final case class EditPullRequest(
     title: Option[String],
@@ -267,14 +270,14 @@ object PullRequests {
 
     implicit val encoder = new Encoder[CreatePullRequest]{
       def apply(a: CreatePullRequest): Json = a match {
-        case PullRequest(title, body, head, base) => 
+        case PullRequest(title, body, head, base) =>
           Json.obj(
             "title" -> title.asJson,
             "body" -> body.asJson,
             "head" -> head.asJson,
             "base" -> base.asJson
           )
-        case Issue(issueNumber, head, base) => 
+        case Issue(issueNumber, head, base) =>
           Json.obj(
             "issue" -> issueNumber.asJson,
             "head" -> head.asJson,
@@ -299,7 +302,7 @@ object PullRequests {
     case object Edited extends PullRequestEventType
 
     implicit val decoder = new Decoder[PullRequestEventType]{
-      def apply(c: HCursor): Decoder.Result[PullRequestEventType] = 
+      def apply(c: HCursor): Decoder.Result[PullRequestEventType] =
         c.as[String].flatMap{
           case "opened" => Opened.asRight
           case "closed" => Closed.asRight
@@ -326,7 +329,7 @@ object PullRequests {
   )
   object PullRequestEvent {
     implicit val decoder = new Decoder[PullRequestEvent]{
-      def apply(c: HCursor): Decoder.Result[PullRequestEvent] = 
+      def apply(c: HCursor): Decoder.Result[PullRequestEvent] =
         (
           c.downField("action").as[PullRequestEventType],
           c.downField("number").as[Int],
@@ -336,5 +339,5 @@ object PullRequests {
         ).mapN(PullRequestEvent.apply)
     }
   }
-  
+
 }

--- a/core/src/main/scala/io/chrisdavenport/github/data/Repositories.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/data/Repositories.scala
@@ -1,11 +1,14 @@
 package io.chrisdavenport.github.data
 
 import cats.implicits._
-import org.http4s.Uri
-import org.http4s.circe._
-import java.time.Instant
+
 import io.circe._
 import io.circe.syntax._
+
+import org.http4s.Uri
+import org.http4s.circe._
+
+import java.time.ZonedDateTime
 
 object Repositories {
 
@@ -15,7 +18,7 @@ object Repositories {
   )
   object RepoRef {
     implicit val repoRefDecoder=  new Decoder[RepoRef]{
-      def apply(c: HCursor): Decoder.Result[RepoRef] = 
+      def apply(c: HCursor): Decoder.Result[RepoRef] =
         (
           c.downField("owner").as[Users.SimpleOwner],
           c.downField("name").as[String]
@@ -42,11 +45,11 @@ object Repositories {
     homepage: Option[String],
     canFork: Option[Boolean],
     size: Option[Int],
-    updatedAt: Option[Instant],
+    updatedAt: Option[ZonedDateTime],
     watchers: Option[Int],
     language: Option[String],
     defaultBranch: Option[String],
-    pushedAt: Option[Instant], // None for new Repos
+    pushedAt: Option[ZonedDateTime], // None for new Repos
     openIssues: Option[Int],
     hasWiki: Option[Boolean],
     hasIssues: Option[Boolean],
@@ -56,7 +59,7 @@ object Repositories {
   )
   object Repo {
     implicit val repoDecoder =new Decoder[Repo]{
-      def apply(c: HCursor): Decoder.Result[Repo] = 
+      def apply(c: HCursor): Decoder.Result[Repo] =
         ((
           c.downField("name").as[String],
           c.downField("id").as[Int],
@@ -77,12 +80,12 @@ object Repositories {
           c.downField("homepage").as[Option[String]],
           c.downField("fork").as[Option[Boolean]],
           c.downField("size").as[Option[Int]],
-          c.downField("updated_at").as[Option[Instant]],
+          c.downField("updated_at").as[Option[ZonedDateTime]],
           c.downField("watchers").as[Option[Int]],
           c.downField("language").as[Option[String]],
           c.downField("default_branch").as[Option[String]]
         ).tupled,
-          c.downField("pushed_at").as[Option[Instant]],
+          c.downField("pushed_at").as[Option[ZonedDateTime]],
           c.downField("open_issues").as[Option[Int]],
           c.downField("has_wiki").as[Option[Boolean]],
           c.downField("has_issues").as[Option[Boolean]],
@@ -141,7 +144,7 @@ object Repositories {
   )
   object NewRepo {
     def create(name: String): NewRepo = NewRepo(name, None, None, None, None, None, None)
-    
+
     implicit val newRepoEncoder = new Encoder[NewRepo]{
       def apply(a: NewRepo): Json = Json.obj(
         "name" -> a.name.asJson,
@@ -165,7 +168,7 @@ object Repositories {
     hasDownloads: Option[Boolean]
   )
   object EditRepo {
-    
+
     implicit val editRepoEncoder = new Encoder[EditRepo]{
       def apply(a: EditRepo): Json = Json.obj(
         "name" -> a.name.asJson,

--- a/core/src/main/scala/io/chrisdavenport/github/data/Users.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/data/Users.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import cats.effect._
 import org.http4s.Uri
 import org.http4s.circe._
-import java.time.Instant
+import java.time.ZonedDateTime
 
 import io.circe._
 
@@ -16,7 +16,7 @@ object Users {
     object Organization extends OwnerType
 
     implicit val ownerTypeDecoder = new Decoder[OwnerType]{
-      def apply(c: HCursor): Decoder.Result[OwnerType] =  
+      def apply(c: HCursor): Decoder.Result[OwnerType] =
         c.as[String].flatMap{
           case "User" => User.pure[Decoder.Result]
           case "Organization" => Organization.pure[Decoder.Result]
@@ -61,7 +61,7 @@ object Users {
   ) extends SimpleOwner
   object SimpleOrganization {
     implicit val simpleOrganizationDecoder = new Decoder[SimpleOrganization]{
-      def apply(c: HCursor): Decoder.Result[SimpleOrganization] = 
+      def apply(c: HCursor): Decoder.Result[SimpleOrganization] =
       (
         c.downField("id").as[Int],
         c.downField("login").as[String],
@@ -73,9 +73,9 @@ object Users {
 
   object SimpleOwner {
     implicit val simpleOwnerDecoder = new Decoder[SimpleOwner]{
-      def apply(c: HCursor): Decoder.Result[SimpleOwner] = 
+      def apply(c: HCursor): Decoder.Result[SimpleOwner] =
         c.downField("type").as[OwnerType].flatMap{
-          case OwnerType.Organization => 
+          case OwnerType.Organization =>
             SimpleUser.simpleUserDecoder(c)
           case OwnerType.User =>
             SimpleOrganization.simpleOrganizationDecoder(c)
@@ -90,7 +90,7 @@ object Users {
     name: Option[String],
     email: Option[String],
     company: Option[String],
-    createdAt: Option[Instant],
+    createdAt: Option[ZonedDateTime],
     blog: Option[String],
     location: Option[String],
     bio: Option[String],
@@ -105,14 +105,14 @@ object Users {
   ) extends Owner
   object User {
     implicit val userDecoder = new Decoder[User]{
-      def apply(c: HCursor): Decoder.Result[User] = 
+      def apply(c: HCursor): Decoder.Result[User] =
         (
           c.downField("id").as[Int],
           c.downField("login").as[String],
           c.downField("name").as[Option[String]],
           c.downField("email").as[Option[String]],
           c.downField("company").as[Option[String]],
-          c.downField("created_at").as[Option[Instant]],
+          c.downField("created_at").as[Option[ZonedDateTime]],
           c.downField("blog").as[Option[String]],
           c.downField("location").as[Option[String]],
           c.downField("bio").as[Option[String]],
@@ -135,7 +135,7 @@ object Users {
     name: Option[String],
     email: Option[String],
     company: Option[String],
-    createdAt: Instant,
+    createdAt: ZonedDateTime,
     blog: Option[String],
     location: Option[String],
     publicRepos: Int,
@@ -148,14 +148,14 @@ object Users {
   ) extends Owner
   object Organization {
     implicit val organizationDecoder = new Decoder[Organization]{
-      def apply(c: HCursor): Decoder.Result[Organization] = 
+      def apply(c: HCursor): Decoder.Result[Organization] =
         (
           c.downField("id").as[Int],
           c.downField("login").as[String],
           c.downField("name").as[Option[String]],
           c.downField("email").as[Option[String]],
           c.downField("company").as[Option[String]],
-          c.downField("created_at").as[Instant],
+          c.downField("created_at").as[ZonedDateTime],
           c.downField("blog").as[Option[String]],
           c.downField("location").as[Option[String]],
           c.downField("public_repos").as[Int],
@@ -170,11 +170,11 @@ object Users {
   }
   object Owner {
     implicit val ownerDecoder = new Decoder[Owner]{
-      def apply(c: HCursor): Decoder.Result[Owner] = 
+      def apply(c: HCursor): Decoder.Result[Owner] =
         c.downField("type").as[OwnerType].flatMap{
           case OwnerType.User =>
             User.userDecoder(c)
-          case OwnerType.Organization => 
+          case OwnerType.Organization =>
             Organization.organizationDecoder(c)
         }
     }


### PR DESCRIPTION
As it is said in the documentation (https://developer.github.com/v3/#timezones), GitHub API returns instant, but some of them includes also timezone if necessary. That is why we should change the type from `java.time.Instant` (which does not hold timezone information) to `java.time.ZonedDateTime`.