### PR TITLE
fix encoder

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/github/data/Teams.scala
+++ b/core/src/main/scala/io/chrisdavenport/github/data/Teams.scala
@@ -32,7 +32,7 @@ object Teams {
   object AddTeamRepoPermission {
     implicit val encoder: Encoder[AddTeamRepoPermission] = new Encoder[AddTeamRepoPermission]{
       def apply(a: AddTeamRepoPermission): Json = Json.obj(
-        "permissions" -> a.permission.asJson
+        "permission" -> a.permission.asJson
       )
     }
   }


### PR DESCRIPTION
always results in read permission being added
```
curl -L -v \
  -X PUT \
  -H "Accept: application/vnd.github.v3+json" \
  -H "User-Agent: github.scala/v0.4.0" \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  https://api.github.com/teams/{team_id}/repos/{owner}/checks-api \
  -d '{"permissions":"admin"}'
```

https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions-legacy